### PR TITLE
Update run-all script to run CatalogManager

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -39,7 +39,7 @@ popd >/dev/null
 echo "Cart UI running with PID ${UI_PID} at http://localhost:3000"
 
 # Start CatalogManager MAUI app
-dotnet run --project CatalogManager > logs/catalogmanager.log 2>&1 &
+dotnet run --framework net8.0-maccatalyst --project CatalogManager > logs/catalogmanager.log 2>&1 &
 CAT_PID=$!
 
 echo "CatalogManager running with PID ${CAT_PID}"


### PR DESCRIPTION
## Summary
- run CatalogManager as macOS Catalyst from `run-all.sh`

## Testing
- `dotnet test CartHost.Tests/CartHost.Tests.csproj --no-build --verbosity normal` *(fails to discover tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c150feb88832b8b243da231bfc52a